### PR TITLE
Port Molecule Torque calculation to the GPU

### DIFF
--- a/src/CalculateEnergy.cpp
+++ b/src/CalculateEnergy.cpp
@@ -1418,9 +1418,25 @@ void CalculateEnergy::CalculateTorque(std::vector<int> &moleculeIndex,
     double *torquex = molTorque.x;
     double *torquey = molTorque.y;
     double *torquez = molTorque.z;
+#ifdef GOMC_CUDA
+int numOfMolecules = com.Count();
+/*
+for (int i = 0; i < numOfMolecules; i++) {
+    printf("Torque for molecule %d is (%f, %f, %f)\n", i, torquex[i], torquey[i], torquez[i]);
+  }
+*/
+    CallCalculateTorqueGPU(forcefield.particles->getCUDAVars(), moleculeIndex,
+                           coordinates, com, atomForce, atomForceRec, molTorque,
+                           box, currentAxes);
+    
+     for (int i = 0; i < numOfMolecules; i++) {
+    printf("Torque for molecule %d is (%lf, %lf, %lf)\n", i, torquex[i], torquey[i], torquez[i]);
+  }
+  exit(0);
+#else
 #if defined _OPENMP
-#pragma omp parallel for default(none)                                         \
-    shared(atomForce, atomForceRec, com, coordinates, moleculeIndex, torquex,  \
+#pragma omp parallel for default(none)                                         
+    shared(atomForce, atomForceRec, com, coordinates, moleculeIndex, torquex,  
                torquey, torquez) firstprivate(box)
 #endif
     for (int m = 0; m < (int)moleculeIndex.size(); ++m) {
@@ -1445,105 +1461,226 @@ void CalculateEnergy::CalculateTorque(std::vector<int> &moleculeIndex,
       torquez[mIndex] = tz;
     }
   }
-  GOMC_EVENT_STOP(1, GomcProfileEvent::BOX_TORQUE);
+#endif
+    GOMC_EVENT_STOP(1, GomcProfileEvent::BOX_TORQUE);
+}
 }
 
-void CalculateEnergy::ResetForce(XYZArray &atomForce, XYZArray &molForce,
-                                 uint box) {
-  if (multiParticleEnabled) {
-    uint length, start;
 
-    // molecule iterator
-    MoleculeLookup::box_iterator thisMol = molLookup.BoxBegin(box);
-    MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
+  void CalculateEnergy::ResetForce(XYZArray & atomForce, XYZArray & molForce,
+                                   uint box) {
+    if (multiParticleEnabled) {
+      uint length, start;
 
-    while (thisMol != end) {
-      length = mols.GetKind(*thisMol).NumAtoms();
-      start = mols.MolStart(*thisMol);
+      // molecule iterator
+      MoleculeLookup::box_iterator thisMol = molLookup.BoxBegin(box);
+      MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
 
-      molForce.Set(*thisMol, 0.0, 0.0, 0.0);
-      for (uint p = start; p < start + length; p++) {
-        atomForce.Set(p, 0.0, 0.0, 0.0);
+      while (thisMol != end) {
+        length = mols.GetKind(*thisMol).NumAtoms();
+        start = mols.MolStart(*thisMol);
+
+        molForce.Set(*thisMol, 0.0, 0.0, 0.0);
+        for (uint p = start; p < start + length; p++) {
+          atomForce.Set(p, 0.0, 0.0, 0.0);
+        }
+        thisMol++;
       }
-      thisMol++;
     }
   }
-}
 
-uint CalculateEnergy::NumberOfParticlesInsideBox(uint box) {
-  uint numberOfAtoms = 0;
+  uint CalculateEnergy::NumberOfParticlesInsideBox(uint box) {
+    uint numberOfAtoms = 0;
 
-  for (int k = 0; k < (int)mols.GetKindsCount(); k++) {
-    MoleculeKind const &thisKind = mols.kinds[k];
-    numberOfAtoms += thisKind.NumAtoms() * molLookup.NumKindInBox(k, box);
+    for (int k = 0; k < (int)mols.GetKindsCount(); k++) {
+      MoleculeKind const &thisKind = mols.kinds[k];
+      numberOfAtoms += thisKind.NumAtoms() * molLookup.NumKindInBox(k, box);
+    }
+
+    return numberOfAtoms;
   }
 
-  return numberOfAtoms;
-}
+  bool CalculateEnergy::FindMolInCavity(std::vector<std::vector<uint>> & mol,
+                                        const XYZ &center, const XYZ &cavDim,
+                                        const XYZArray &invCav, const uint box,
+                                        const uint kind, const uint exRatio) {
+    uint k;
+    mol.clear();
+    mol.resize(molLookup.GetNumKind());
+    double maxLength = cavDim.Max();
 
-bool CalculateEnergy::FindMolInCavity(std::vector<std::vector<uint>> &mol,
-                                      const XYZ &center, const XYZ &cavDim,
-                                      const XYZArray &invCav, const uint box,
-                                      const uint kind, const uint exRatio) {
-  uint k;
-  mol.clear();
-  mol.resize(molLookup.GetNumKind());
-  double maxLength = cavDim.Max();
+    if (maxLength <= currentAxes.rCut[box]) {
+      CellList::Neighbors n = cellList.EnumerateLocal(center, box);
+      while (!n.Done()) {
+        if (currentAxes.InCavity(currentCOM.Get(particleMol[*n]), center,
+                                 cavDim, invCav, box)) {
+          uint molIndex = particleMol[*n];
+          // if molecule can be transfer between boxes
+          if (!molLookup.IsNoSwap(molIndex)) {
+            k = mols.GetMolKind(molIndex);
+            bool exist = std::find(mol[k].begin(), mol[k].end(), molIndex) !=
+                         mol[k].end();
+            if (!exist)
+              mol[k].push_back(molIndex);
+          }
+        }
+        n.Next();
+      }
+    } else {
+      MoleculeLookup::box_iterator n = molLookup.BoxBegin(box);
+      MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
+      while (n != end) {
+        if (currentAxes.InCavity(currentCOM.Get(*n), center, cavDim, invCav,
+                                 box)) {
+          uint molIndex = *n;
+          // if molecule can be transfer between boxes
+          if (!molLookup.IsNoSwap(molIndex)) {
+            k = mols.GetMolKind(molIndex);
+            bool exist = std::find(mol[k].begin(), mol[k].end(), molIndex) !=
+                         mol[k].end();
+            if (!exist)
+              mol[k].push_back(molIndex);
+          }
+        }
+        n++;
+      }
+    }
 
-  if (maxLength <= currentAxes.rCut[box]) {
-    CellList::Neighbors n = cellList.EnumerateLocal(center, box);
-    while (!n.Done()) {
-      if (currentAxes.InCavity(currentCOM.Get(particleMol[*n]), center, cavDim,
-                               invCav, box)) {
-        uint molIndex = particleMol[*n];
-        // if molecule can be transfer between boxes
-        if (!molLookup.IsNoSwap(molIndex)) {
-          k = mols.GetMolKind(molIndex);
-          bool exist =
-              std::find(mol[k].begin(), mol[k].end(), molIndex) != mol[k].end();
-          if (!exist)
-            mol[k].push_back(molIndex);
+    // If the is exRate and more molecule kind in cavity, return true.
+    if (mol[kind].size() >= exRatio)
+      return true;
+    else
+      return false;
+  }
+
+  void CalculateEnergy::SingleMoleculeInter(
+      Energy & interEnOld, Energy & interEnNew, const double lambdaOldVDW,
+      const double lambdaNewVDW, const double lambdaOldCoulomb,
+      const double lambdaNewCoulomb, const uint molIndex, const uint box)
+      const {
+    double tempREnOld = 0.0, tempLJEnOld = 0.0;
+    double tempREnNew = 0.0, tempLJEnNew = 0.0;
+    if (box < BOXES_WITH_U_NB) {
+      uint length = mols.GetKind(molIndex).NumAtoms();
+      uint start = mols.MolStart(molIndex);
+
+      for (uint p = 0; p < length; ++p) {
+        uint atom = start + p;
+        CellList::Neighbors n =
+            cellList.EnumerateLocal(currentCoords[atom], box);
+
+        std::vector<uint> nIndex;
+        // store atom index in neighboring cell
+        while (!n.Done()) {
+          if (particleMol[*n] != (int)molIndex) {
+            nIndex.push_back(*n);
+          }
+          n.Next();
+        }
+
+#ifdef _OPENMP
+#pragma omp parallel for default(none) shared(nIndex)                          \
+    firstprivate(atom, box, lambdaNewCoulomb, lambdaNewVDW, lambdaOldCoulomb,  \
+                     lambdaOldVDW, num::qqFact)                                \
+    reduction(+ : tempREnOld, tempLJEnOld, tempREnNew, tempLJEnNew)
+#endif
+        for (int i = 0; i < (int)nIndex.size(); i++) {
+          double distSq = 0.0;
+          XYZ virComponents;
+          if (currentAxes.InRcut(distSq, virComponents, currentCoords, atom,
+                                 nIndex[i], box)) {
+            if (electrostatic) {
+              double qi_qj_fact = particleCharge[atom] *
+                                  particleCharge[nIndex[i]] * num::qqFact;
+              if (qi_qj_fact != 0.0) {
+                tempREnNew += forcefield.particles->CalcCoulomb(
+                    distSq, particleKind[atom], particleKind[nIndex[i]],
+                    qi_qj_fact, lambdaNewCoulomb, box);
+                tempREnOld += forcefield.particles->CalcCoulomb(
+                    distSq, particleKind[atom], particleKind[nIndex[i]],
+                    qi_qj_fact, lambdaOldCoulomb, box);
+              }
+            }
+
+            tempLJEnNew += forcefield.particles->CalcEn(
+                distSq, particleKind[atom], particleKind[nIndex[i]],
+                lambdaNewVDW);
+            tempLJEnOld += forcefield.particles->CalcEn(
+                distSq, particleKind[atom], particleKind[nIndex[i]],
+                lambdaOldVDW);
+          }
         }
       }
-      n.Next();
     }
-  } else {
-    MoleculeLookup::box_iterator n = molLookup.BoxBegin(box);
-    MoleculeLookup::box_iterator end = molLookup.BoxEnd(box);
-    while (n != end) {
-      if (currentAxes.InCavity(currentCOM.Get(*n), center, cavDim, invCav,
-                               box)) {
-        uint molIndex = *n;
-        // if molecule can be transfer between boxes
-        if (!molLookup.IsNoSwap(molIndex)) {
-          k = mols.GetMolKind(molIndex);
-          bool exist =
-              std::find(mol[k].begin(), mol[k].end(), molIndex) != mol[k].end();
-          if (!exist)
-            mol[k].push_back(molIndex);
-        }
-      }
-      n++;
-    }
+
+    interEnNew.inter = tempLJEnNew;
+    interEnNew.real = tempREnNew;
+    interEnOld.inter = tempLJEnOld;
+    interEnOld.real = tempREnOld;
   }
 
-  // If the is exRate and more molecule kind in cavity, return true.
-  if (mol[kind].size() >= exRatio)
-    return true;
-  else
-    return false;
-}
+  double CalculateEnergy::GetLambdaVDW(uint molA, uint molB, uint box) const {
+    double lambda = 1.0;
+    lambda *= lambdaRef.GetLambdaVDW(molA, box);
+    lambda *= lambdaRef.GetLambdaVDW(molB, box);
+    return lambda;
+  }
 
-void CalculateEnergy::SingleMoleculeInter(
-    Energy &interEnOld, Energy &interEnNew, const double lambdaOldVDW,
-    const double lambdaNewVDW, const double lambdaOldCoulomb,
-    const double lambdaNewCoulomb, const uint molIndex, const uint box) const {
-  double tempREnOld = 0.0, tempLJEnOld = 0.0;
-  double tempREnNew = 0.0, tempLJEnNew = 0.0;
-  if (box < BOXES_WITH_U_NB) {
+  double CalculateEnergy::GetLambdaCoulomb(uint molA, uint molB, uint box)
+      const {
+    double lambda = 1.0;
+    lambda *= lambdaRef.GetLambdaCoulomb(molA, box);
+    lambda *= lambdaRef.GetLambdaCoulomb(molB, box);
+    // no need for sq root for inter energy. Always one of the molecules has
+    // lambda 1
+    return lambda;
+  }
+
+  // Calculates the change in the TC from adding numChange atoms of a kind
+  double CalculateEnergy::MoleculeTailChange(
+      const uint box, const uint kind, const std::vector<uint> &kCount,
+      const double lambdaOld, const double lambdaNew) const {
+    if (box >= BOXES_WITH_U_NB) {
+      return 0.0;
+    }
+
+    double tcDiff = 0.0;
+    uint ktot = mols.GetKindsCount();
+    for (uint i = 0; i < ktot; ++i) {
+      // We should have only one molecule of fractional kind
+      double rhoDeltaIJ_2 = 2.0 * (double)(kCount[i]) * currentAxes.volInv[box];
+      uint index = kind * ktot + i;
+      tcDiff += (lambdaNew - lambdaOld) * mols.pairEnCorrections[index] *
+                rhoDeltaIJ_2;
+    }
+    uint index = kind * ktot + kind;
+    tcDiff += (lambdaNew - lambdaOld) * mols.pairEnCorrections[index] *
+              currentAxes.volInv[box];
+
+    return tcDiff;
+  }
+
+  // Calculate the change in energy due to lambda
+  void CalculateEnergy::EnergyChange(
+      Energy * energyDiff, Energy & dUdL_VDW, Energy & dUdL_Coul,
+      const std::vector<double> &lambda_VDW,
+      const std::vector<double> &lambda_Coul, const uint iState,
+      const uint molIndex, const uint box) const {
+    if (box >= BOXES_WITH_U_NB) {
+      return;
+    }
+
+    GOMC_EVENT_START(1, GomcProfileEvent::FREE_ENERGY);
     uint length = mols.GetKind(molIndex).NumAtoms();
     uint start = mols.MolStart(molIndex);
+    uint lambdaSize = lambda_VDW.size();
+    double *tempLJEnDiff = new double[lambdaSize];
+    double *tempREnDiff = new double[lambdaSize];
+    double dudl_VDW = 0.0, dudl_Coul = 0.0;
+    std::fill_n(tempLJEnDiff, lambdaSize, 0.0);
+    std::fill_n(tempREnDiff, lambdaSize, 0.0);
 
+    // Calculate the vdw, short range electrostatic energy
     for (uint p = 0; p < length; ++p) {
       uint atom = start + p;
       CellList::Neighbors n = cellList.EnumerateLocal(currentCoords[atom], box);
@@ -1557,236 +1694,119 @@ void CalculateEnergy::SingleMoleculeInter(
         n.Next();
       }
 
-#ifdef _OPENMP
-#pragma omp parallel for default(none) shared(nIndex)                          \
-    firstprivate(atom, box, lambdaNewCoulomb, lambdaNewVDW, lambdaOldCoulomb,  \
-                     lambdaOldVDW, num::qqFact)                                \
-    reduction(+ : tempREnOld, tempLJEnOld, tempREnNew, tempLJEnNew)
-#endif
-      for (int i = 0; i < (int)nIndex.size(); i++) {
-        double distSq = 0.0;
-        XYZ virComponents;
-        if (currentAxes.InRcut(distSq, virComponents, currentCoords, atom,
-                               nIndex[i], box)) {
-          if (electrostatic) {
-            double qi_qj_fact =
-                particleCharge[atom] * particleCharge[nIndex[i]] * num::qqFact;
-            if (qi_qj_fact != 0.0) {
-              tempREnNew += forcefield.particles->CalcCoulomb(
-                  distSq, particleKind[atom], particleKind[nIndex[i]],
-                  qi_qj_fact, lambdaNewCoulomb, box);
-              tempREnOld += forcefield.particles->CalcCoulomb(
-                  distSq, particleKind[atom], particleKind[nIndex[i]],
-                  qi_qj_fact, lambdaOldCoulomb, box);
-            }
-          }
-
-          tempLJEnNew += forcefield.particles->CalcEn(
-              distSq, particleKind[atom], particleKind[nIndex[i]],
-              lambdaNewVDW);
-          tempLJEnOld += forcefield.particles->CalcEn(
-              distSq, particleKind[atom], particleKind[nIndex[i]],
-              lambdaOldVDW);
-        }
-      }
-    }
-  }
-
-  interEnNew.inter = tempLJEnNew;
-  interEnNew.real = tempREnNew;
-  interEnOld.inter = tempLJEnOld;
-  interEnOld.real = tempREnOld;
-}
-
-double CalculateEnergy::GetLambdaVDW(uint molA, uint molB, uint box) const {
-  double lambda = 1.0;
-  lambda *= lambdaRef.GetLambdaVDW(molA, box);
-  lambda *= lambdaRef.GetLambdaVDW(molB, box);
-  return lambda;
-}
-
-double CalculateEnergy::GetLambdaCoulomb(uint molA, uint molB, uint box) const {
-  double lambda = 1.0;
-  lambda *= lambdaRef.GetLambdaCoulomb(molA, box);
-  lambda *= lambdaRef.GetLambdaCoulomb(molB, box);
-  // no need for sq root for inter energy. Always one of the molecules has
-  // lambda 1
-  return lambda;
-}
-
-// Calculates the change in the TC from adding numChange atoms of a kind
-double CalculateEnergy::MoleculeTailChange(const uint box, const uint kind,
-                                           const std::vector<uint> &kCount,
-                                           const double lambdaOld,
-                                           const double lambdaNew) const {
-  if (box >= BOXES_WITH_U_NB) {
-    return 0.0;
-  }
-
-  double tcDiff = 0.0;
-  uint ktot = mols.GetKindsCount();
-  for (uint i = 0; i < ktot; ++i) {
-    // We should have only one molecule of fractional kind
-    double rhoDeltaIJ_2 = 2.0 * (double)(kCount[i]) * currentAxes.volInv[box];
-    uint index = kind * ktot + i;
-    tcDiff +=
-        (lambdaNew - lambdaOld) * mols.pairEnCorrections[index] * rhoDeltaIJ_2;
-  }
-  uint index = kind * ktot + kind;
-  tcDiff += (lambdaNew - lambdaOld) * mols.pairEnCorrections[index] *
-            currentAxes.volInv[box];
-
-  return tcDiff;
-}
-
-// Calculate the change in energy due to lambda
-void CalculateEnergy::EnergyChange(Energy *energyDiff, Energy &dUdL_VDW,
-                                   Energy &dUdL_Coul,
-                                   const std::vector<double> &lambda_VDW,
-                                   const std::vector<double> &lambda_Coul,
-                                   const uint iState, const uint molIndex,
-                                   const uint box) const {
-  if (box >= BOXES_WITH_U_NB) {
-    return;
-  }
-
-  GOMC_EVENT_START(1, GomcProfileEvent::FREE_ENERGY);
-  uint length = mols.GetKind(molIndex).NumAtoms();
-  uint start = mols.MolStart(molIndex);
-  uint lambdaSize = lambda_VDW.size();
-  double *tempLJEnDiff = new double[lambdaSize];
-  double *tempREnDiff = new double[lambdaSize];
-  double dudl_VDW = 0.0, dudl_Coul = 0.0;
-  std::fill_n(tempLJEnDiff, lambdaSize, 0.0);
-  std::fill_n(tempREnDiff, lambdaSize, 0.0);
-
-  // Calculate the vdw, short range electrostatic energy
-  for (uint p = 0; p < length; ++p) {
-    uint atom = start + p;
-    CellList::Neighbors n = cellList.EnumerateLocal(currentCoords[atom], box);
-
-    std::vector<uint> nIndex;
-    // store atom index in neighboring cell
-    while (!n.Done()) {
-      if (particleMol[*n] != (int)molIndex) {
-        nIndex.push_back(*n);
-      }
-      n.Next();
-    }
-
 #if defined _OPENMP && _OPENMP >= 201511 // check if OpenMP version is 4.5
 #pragma omp parallel for default(none) shared(lambda_Coul, lambda_VDW, nIndex) \
     firstprivate(atom, box, iState, lambdaSize, num::qqFact)                   \
     reduction(+ : dudl_VDW, dudl_Coul, tempREnDiff[ : lambdaSize],             \
                   tempLJEnDiff[ : lambdaSize])
 #endif
-    for (int i = 0; i < (int)nIndex.size(); i++) {
-      double distSq = 0.0;
-      XYZ virComponents;
-      if (currentAxes.InRcut(distSq, virComponents, currentCoords, atom,
-                             nIndex[i], box)) {
-        double qi_qj_fact = 0.0, energyOldCoul = 0.0;
-        // Calculate the energy of current state
-        double energyOldVDW = forcefield.particles->CalcEn(
-            distSq, particleKind[atom], particleKind[nIndex[i]],
-            lambda_VDW[iState]);
-        // Calculate du/dl in VDW for current state
-        dudl_VDW += forcefield.particles->CalcdEndL(distSq, particleKind[atom],
-                                                    particleKind[nIndex[i]],
-                                                    lambda_VDW[iState]);
-
-        if (electrostatic) {
-          qi_qj_fact =
-              particleCharge[atom] * particleCharge[nIndex[i]] * num::qqFact;
-          if (qi_qj_fact != 0.0) {
-            energyOldCoul = forcefield.particles->CalcCoulomb(
-                distSq, particleKind[atom], particleKind[nIndex[i]], qi_qj_fact,
-                lambda_Coul[iState], box);
-            // Calculate du/dl in Coulomb for current state.
-            dudl_Coul += forcefield.particles->CalcCoulombdEndL(
-                distSq, particleKind[atom], particleKind[nIndex[i]], qi_qj_fact,
-                lambda_Coul[iState], box);
-          }
-        }
-
-        for (int s = 0; s < (int)lambdaSize; s++) {
-          // Calculate the energy of other state
-          tempLJEnDiff[s] += forcefield.particles->CalcEn(
+      for (int i = 0; i < (int)nIndex.size(); i++) {
+        double distSq = 0.0;
+        XYZ virComponents;
+        if (currentAxes.InRcut(distSq, virComponents, currentCoords, atom,
+                               nIndex[i], box)) {
+          double qi_qj_fact = 0.0, energyOldCoul = 0.0;
+          // Calculate the energy of current state
+          double energyOldVDW = forcefield.particles->CalcEn(
               distSq, particleKind[atom], particleKind[nIndex[i]],
-              lambda_VDW[s]);
-          tempLJEnDiff[s] += -energyOldVDW;
-          if (electrostatic && qi_qj_fact != 0.0) {
-            tempREnDiff[s] += forcefield.particles->CalcCoulomb(
-                distSq, particleKind[atom], particleKind[nIndex[i]], qi_qj_fact,
-                lambda_Coul[s], box);
-            tempREnDiff[s] += -energyOldCoul;
+              lambda_VDW[iState]);
+          // Calculate du/dl in VDW for current state
+          dudl_VDW += forcefield.particles->CalcdEndL(
+              distSq, particleKind[atom], particleKind[nIndex[i]],
+              lambda_VDW[iState]);
+
+          if (electrostatic) {
+            qi_qj_fact =
+                particleCharge[atom] * particleCharge[nIndex[i]] * num::qqFact;
+            if (qi_qj_fact != 0.0) {
+              energyOldCoul = forcefield.particles->CalcCoulomb(
+                  distSq, particleKind[atom], particleKind[nIndex[i]],
+                  qi_qj_fact, lambda_Coul[iState], box);
+              // Calculate du/dl in Coulomb for current state.
+              dudl_Coul += forcefield.particles->CalcCoulombdEndL(
+                  distSq, particleKind[atom], particleKind[nIndex[i]],
+                  qi_qj_fact, lambda_Coul[iState], box);
+            }
+          }
+
+          for (int s = 0; s < (int)lambdaSize; s++) {
+            // Calculate the energy of other state
+            tempLJEnDiff[s] += forcefield.particles->CalcEn(
+                distSq, particleKind[atom], particleKind[nIndex[i]],
+                lambda_VDW[s]);
+            tempLJEnDiff[s] += -energyOldVDW;
+            if (electrostatic && qi_qj_fact != 0.0) {
+              tempREnDiff[s] += forcefield.particles->CalcCoulomb(
+                  distSq, particleKind[atom], particleKind[nIndex[i]],
+                  qi_qj_fact, lambda_Coul[s], box);
+              tempREnDiff[s] += -energyOldCoul;
+            }
           }
         }
       }
     }
+
+    dUdL_VDW.inter = dudl_VDW;
+    dUdL_Coul.real = dudl_Coul;
+    for (int s = 0; s < (int)lambdaSize; s++) {
+      energyDiff[s].inter += tempLJEnDiff[s];
+      energyDiff[s].real += tempREnDiff[s];
+    }
+    delete[] tempLJEnDiff;
+    delete[] tempREnDiff;
+
+    if (forcefield.useLRC) {
+      // Need to calculate change in LRC
+      ChangeLRC(energyDiff, dUdL_VDW, lambda_VDW, iState, molIndex, box);
+    }
+    // Need to calculate change in self
+    calcEwald->ChangeSelf(energyDiff, dUdL_Coul, lambda_Coul, iState, molIndex,
+                          box);
+    // Need to calculate change in correction
+    calcEwald->ChangeCorrection(energyDiff, dUdL_Coul, lambda_Coul, iState,
+                                molIndex, box);
+    // Need to calculate change in Reciprocal
+    calcEwald->ChangeRecip(energyDiff, dUdL_Coul, lambda_Coul, iState, molIndex,
+                           box);
+    GOMC_EVENT_STOP(1, GomcProfileEvent::FREE_ENERGY);
   }
 
-  dUdL_VDW.inter = dudl_VDW;
-  dUdL_Coul.real = dudl_Coul;
-  for (int s = 0; s < (int)lambdaSize; s++) {
-    energyDiff[s].inter += tempLJEnDiff[s];
-    energyDiff[s].real += tempREnDiff[s];
-  }
-  delete[] tempLJEnDiff;
-  delete[] tempREnDiff;
+  // Calculate the change in LRC for each state
+  void CalculateEnergy::ChangeLRC(Energy * energyDiff, Energy & dUdL_VDW,
+                                  const std::vector<double> &lambda_VDW,
+                                  const uint iState, const uint molIndex,
+                                  const uint box) const {
+    // Get the kind and lambda value
+    uint fk = mols.GetMolKind(molIndex);
+    double lambda_istate = lambda_VDW[iState];
 
-  if (forcefield.useLRC) {
-    // Need to calculate change in LRC
-    ChangeLRC(energyDiff, dUdL_VDW, lambda_VDW, iState, molIndex, box);
-  }
-  // Need to calculate change in self
-  calcEwald->ChangeSelf(energyDiff, dUdL_Coul, lambda_Coul, iState, molIndex,
-                        box);
-  // Need to calculate change in correction
-  calcEwald->ChangeCorrection(energyDiff, dUdL_Coul, lambda_Coul, iState,
-                              molIndex, box);
-  // Need to calculate change in Reciprocal
-  calcEwald->ChangeRecip(energyDiff, dUdL_Coul, lambda_Coul, iState, molIndex,
-                         box);
-  GOMC_EVENT_STOP(1, GomcProfileEvent::FREE_ENERGY);
-}
-
-// Calculate the change in LRC for each state
-void CalculateEnergy::ChangeLRC(Energy *energyDiff, Energy &dUdL_VDW,
-                                const std::vector<double> &lambda_VDW,
-                                const uint iState, const uint molIndex,
-                                const uint box) const {
-  // Get the kind and lambda value
-  uint fk = mols.GetMolKind(molIndex);
-  double lambda_istate = lambda_VDW[iState];
-
-  // Add the LRC for fractional molecule
-  for (size_t s = 0; s < lambda_VDW.size(); s++) {
-    double lambdaVDW = lambda_VDW[s];
-    for (uint i = 0; i < mols.GetKindsCount(); ++i) {
-      uint molNum = molLookup.NumKindInBox(i, box);
-      if (i == fk) {
-        --molNum; // We have one less molecule (it is fractional molecule)
+    // Add the LRC for fractional molecule
+    for (size_t s = 0; s < lambda_VDW.size(); s++) {
+      double lambdaVDW = lambda_VDW[s];
+      for (uint i = 0; i < mols.GetKindsCount(); ++i) {
+        uint molNum = molLookup.NumKindInBox(i, box);
+        if (i == fk) {
+          --molNum; // We have one less molecule (it is fractional molecule)
+        }
+        double rhoDeltaIJ_2 = 2.0 * (double)(molNum)*currentAxes.volInv[box];
+        energyDiff[s].tailCorrection +=
+            mols.pairEnCorrections[fk * mols.GetKindsCount() + i] *
+            rhoDeltaIJ_2 * (lambdaVDW - lambda_istate);
+        if (s == iState) {
+          // Calculate du/dl in VDW LRC for current state
+          dUdL_VDW.tailCorrection +=
+              mols.pairEnCorrections[fk * mols.GetKindsCount() + i] *
+              rhoDeltaIJ_2;
+        }
       }
-      double rhoDeltaIJ_2 = 2.0 * (double)(molNum)*currentAxes.volInv[box];
       energyDiff[s].tailCorrection +=
-          mols.pairEnCorrections[fk * mols.GetKindsCount() + i] * rhoDeltaIJ_2 *
-          (lambdaVDW - lambda_istate);
+          mols.pairEnCorrections[fk * mols.GetKindsCount() + fk] *
+          currentAxes.volInv[box] * (lambdaVDW - lambda_istate);
       if (s == iState) {
         // Calculate du/dl in VDW LRC for current state
         dUdL_VDW.tailCorrection +=
-            mols.pairEnCorrections[fk * mols.GetKindsCount() + i] *
-            rhoDeltaIJ_2;
+            mols.pairEnCorrections[fk * mols.GetKindsCount() + fk] *
+            currentAxes.volInv[box];
       }
     }
-    energyDiff[s].tailCorrection +=
-        mols.pairEnCorrections[fk * mols.GetKindsCount() + fk] *
-        currentAxes.volInv[box] * (lambdaVDW - lambda_istate);
-    if (s == iState) {
-      // Calculate du/dl in VDW LRC for current state
-      dUdL_VDW.tailCorrection +=
-          mols.pairEnCorrections[fk * mols.GetKindsCount() + fk] *
-          currentAxes.volInv[box];
-    }
   }
-}

--- a/src/GPU/CalculateEnergyCUDAKernel.cu
+++ b/src/GPU/CalculateEnergyCUDAKernel.cu
@@ -14,6 +14,74 @@ A copy of the MIT License can be found in License.txt with this program or at
 #include "CalculateForceCUDAKernel.cuh"
 #include "CalculateMinImageCUDAKernel.cuh"
 
+void CallCalculateTorqueGPU(VariablesCUDA *vars,
+                            std::vector<int> &moleculeIndex,
+                            XYZArray const &coordinates, XYZArray const &com,
+                            XYZArray const &atomForce,
+                            XYZArray const &atomForceRec, XYZArray &molTorque,
+                            const uint box, BoxDimensions const &boxAxes) {
+
+  /*
+  Maybe there needs to be memcopies here?
+  We will test without and verify the result
+  */
+  // instead of using imageSize we should grab the value of com.length() for the
+  // number of molecules
+  const int numMolecules = com.Count();
+  cudaMemcpy(vars->gpu_mTorquex, molTorque.x, sizeof(double) * numMolecules,
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(vars->gpu_mTorquey, molTorque.y, sizeof(double) * numMolecules,
+             cudaMemcpyHostToDevice);
+  cudaMemcpy(vars->gpu_mTorquez, molTorque.z, sizeof(double) * numMolecules,
+             cudaMemcpyHostToDevice);
+
+
+  double3 axis = make_double3(boxAxes.GetAxis(box).x, boxAxes.GetAxis(box).y,
+                              boxAxes.GetAxis(box).z);
+
+  double3 halfAx =
+      make_double3(boxAxes.GetAxis(box).x * 0.5, boxAxes.GetAxis(box).y * 0.5,
+                   boxAxes.GetAxis(box).z * 0.5);
+
+  int threadsPerBlock = THREADS_PER_BLOCK_SM;
+  int blocksPerGrid = (numMolecules + threadsPerBlock - 1) / threadsPerBlock;
+
+  checkLastErrorCUDA(__FILE__, __LINE__);  
+
+  CalculateTorqueGPU<<<blocksPerGrid, threadsPerBlock>>>(
+      vars->gpu_startAtomIdx, vars->gpu_molIndex, vars->gpu_x, vars->gpu_y,
+      vars->gpu_z, vars->gpu_comx, vars->gpu_comy, vars->gpu_comz,
+      vars->gpu_aForcex, vars->gpu_aForcey, vars->gpu_aForcez,
+      vars->gpu_aForceRecx, vars->gpu_aForceRecy, vars->gpu_aForceRecz,
+      vars->gpu_mTorquex, vars->gpu_mTorquey, vars->gpu_mTorquez, box,
+      numMolecules, axis, halfAx);
+      
+  cudaDeviceSynchronize();
+  checkLastErrorCUDA(__FILE__, __LINE__);
+
+  
+  // memcopy back to cpu (torquex, torquey, torquez)
+  cudaMemcpy(molTorque.x, vars->gpu_mTorquex, //sizeof(double) * numMolecules,
+             1, cudaMemcpyDeviceToHost);
+  cudaMemcpy(molTorque.y, vars->gpu_mTorquey, //sizeof(double) * numMolecules,
+             1, cudaMemcpyDeviceToHost);
+  cudaMemcpy(molTorque.z, vars->gpu_mTorquez, //sizeof(double) * numMolecules,
+             1, cudaMemcpyDeviceToHost);
+  
+  checkLastErrorCUDA(__FILE__, __LINE__);
+  /*
+             // make pointers to molTorque arrays
+    double *torquex = molTorque.x;
+    double *torquey = molTorque.y;
+    double *torquez = molTorque.z;
+  
+    for (int i = 0; i < numMolecules; i++) {
+    printf("Torque for molecule %d is (%f, %f, %f)\n", i, torquex[i], torquey[i], torquez[i]);
+  }
+  exit(0);
+  */
+}
+
 void CallBoxInterGPU(VariablesCUDA *vars, const std::vector<int> &cellVector,
                      const std::vector<int> &cellStartIndex,
                      XYZArray const &coords, BoxDimensions const &boxAxes,
@@ -79,6 +147,97 @@ void CallBoxInterGPU(VariablesCUDA *vars, const std::vector<int> &cellVector,
 #ifndef NDEBUG
   checkLastErrorCUDA(__FILE__, __LINE__);
 #endif
+}
+
+__global__ void CalculateTorqueGPU(
+    const int *__restrict__ gpu_startAtomIndex, // atom indices
+    const int *__restrict__ gpu_moleculeIndex,  // molecule indices 
+
+    const double *__restrict__ gpu_cx, // x coordinates
+    const double *__restrict__ gpu_cy, // y coordinates
+    const double *__restrict__ gpu_cz, // z coordinates
+
+    const double *__restrict__ gpu_comx, // x center of mass
+    const double *__restrict__ gpu_comy, // y center of mass
+    const double *__restrict__ gpu_comz, // z center of mass
+
+    const double *__restrict__ gpu_atomforcex, // x atom force
+    const double *__restrict__ gpu_atomforcey, // y atom force
+    const double *__restrict__ gpu_atomforcez, // z atom force
+
+    const double *__restrict__ gpu_atomforcerecx, // x atom force reciprocal
+    const double *__restrict__ gpu_atomforcerecy, // y atom force reciprocal
+    const double *__restrict__ gpu_atomforcerecz, // z atom force reciprocal
+
+    double *__restrict__ gpu_moltorquex, // x molecule torque
+    double *__restrict__ gpu_moltorquey, // y molecule torque
+    double *__restrict__ gpu_moltorquez, // z molecule torque
+
+    const uint box,         // box number
+    const uint numMolecules, // number of molecules, if index is above this
+                            // number we should just return
+    const double3 axis,     // lengths in each dimension
+    const double3 halfAx) {
+
+#if defined(NDEBUG) && (__CUDACC_VER_MAJOR__ >= 13)
+  asm volatile(".pragma \"enable_smem_spilling\";");
+#endif
+
+  const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= numMolecules)
+    return;
+
+  int mIndex = gpu_moleculeIndex[idx];
+
+  int start = gpu_startAtomIndex[mIndex];
+  int nextStart = gpu_startAtomIndex[mIndex + 1];
+  // int length = nextStart - start;
+
+  double tx = 0.0;
+  double ty = 0.0;
+  double tz = 0.0;
+
+  double3 molCOM = make_double3(gpu_comx[mIndex], gpu_comy[mIndex], gpu_comz[mIndex]);
+
+  // atom iterator
+  for (int p = start; p < nextStart; ++p) {
+
+    double3 atomCoords = make_double3(gpu_cx[p], gpu_cy[p], gpu_cz[p]);
+    // double3 distFromCOM = molCOM - atomCoords;
+    double3 distFromCOM = make_double3(molCOM.x - atomCoords.x, molCOM.y - atomCoords.y, molCOM.z - atomCoords.z);
+
+    // XYZ distFromCOM = coordinates.Difference(p, com, mIndex);
+
+    distFromCOM = MinImageGPU(distFromCOM, axis, halfAx);
+
+    double3 atomForceTotal =
+        make_double3(gpu_atomforcex[p] + gpu_atomforcerecx[p],
+                     gpu_atomforcey[p] + gpu_atomforcerecy[p],
+                     gpu_atomforcez[p] + gpu_atomforcerecz[p]);
+
+            double3 tempTorque = CrossProductGPU(distFromCOM, atomForceTotal);
+            // double3 tempTorque = make_double3(distFromCOM.x - atomForceTotal.x, distFromCOM.y - atomForceTotal.y, distFromCOM.z - atomForceTotal.z);
+
+    tx += tempTorque.x;
+    ty += tempTorque.y;
+    tz += tempTorque.z;
+    
+  }
+  
+  gpu_moltorquex[mIndex] = tx;
+  gpu_moltorquey[mIndex] = ty;
+  gpu_moltorquez[mIndex] = tz;  
+  
+  printf("MOLTORQUE X: %f\n", gpu_moltorquex[mIndex]);
+}
+
+__device__ inline double3 CrossProductGPU(const double3 &a, const double3 &b) {
+  // implementation
+  double x = a.y * b.z - a.z * b.y;
+  double y = a.z * b.x - a.x * b.z;
+  double z = a.x * b.y - a.y * b.x;
+
+  return make_double3(x, y, z);
 }
 
 __global__ void

--- a/src/GPU/CalculateEnergyCUDAKernel.cuh
+++ b/src/GPU/CalculateEnergyCUDAKernel.cuh
@@ -22,6 +22,47 @@ void CallBoxInterGPU(VariablesCUDA *vars, const std::vector<int> &cellVector,
                      bool sc_coul, double sc_sigma_6, double sc_alpha,
                      uint sc_power, uint const box);
 
+void CallCalculateTorqueGPU(VariablesCUDA *vars,
+                            std::vector<int> &moleculeIndex,
+                            XYZArray const &coordinates, XYZArray const &com,
+                            XYZArray const &atomForce,
+                            XYZArray const &atomForceRec, XYZArray &molTorque,
+                            const uint box, BoxDimensions const &boxAxes);
+
+__global__ void CalculateTorqueGPU(
+    const int *__restrict__ gpu_startAtomIndex, // atom indices
+    const int *__restrict__ gpu_moleculeIndex,  // molecule indices
+
+    const double *__restrict__ gpu_cx, // x coordinates
+    const double *__restrict__ gpu_cy, // y coordinates
+    const double *__restrict__ gpu_cz, // z coordinates
+
+    const double *__restrict__ gpu_comx, // x center of mass
+    const double *__restrict__ gpu_comy, // y center of mass
+    const double *__restrict__ gpu_comz, // z center of mass
+
+    const double *__restrict__ gpu_atomforcex, // x atom force
+    const double *__restrict__ gpu_atomforcey, // y atom force
+    const double *__restrict__ gpu_atomforcez, // z atom force
+
+    const double *__restrict__ gpu_atomforcerecx, // x atom force reciprocal
+    const double *__restrict__ gpu_atomforcerecy, // y atom force reciprocal
+    const double *__restrict__ gpu_atomforcerecz, // z atom force reciprocal
+
+    double *__restrict__ gpu_moltorquex, // x molecule torque
+    double *__restrict__ gpu_moltorquey, // y molecule torque
+    double *__restrict__ gpu_moltorquez, // z molecule torque
+
+    const uint box,         // box number
+    const uint numMolecules, // number of molecules, if index is above this
+                            // number we should just return
+    const double3 axis,     // lengths in each dimension
+    const double3 halfAx    // half of axis
+);
+
+
+__device__ inline double3 CrossProductGPU(const double3 &a, const double3 &b);
+
 __global__ void
 BoxInterGPU(int *gpu_cellStartIndex, int *gpu_cellVector, int *gpu_neighborList,
             int numberOfCells, double *gpu_x, double *gpu_y, double *gpu_z,

--- a/src/GPU/VariablesCUDA.cuh
+++ b/src/GPU/VariablesCUDA.cuh
@@ -29,7 +29,7 @@ inline void gpuAssert(cudaError_t code, const char *file, int line,
   }
 }
 
-#ifndef NDEBUG
+//#ifndef NDEBUG
 inline void checkLastErrorCUDA(const char *file, int line) {
   cudaError_t code = cudaGetLastError();
   if (code != cudaSuccess) {
@@ -38,7 +38,7 @@ inline void checkLastErrorCUDA(const char *file, int line) {
     exit(code);
   }
 }
-#endif
+//#endif
 
 inline void printFreeMemory() {
   size_t free_byte;


### PR DESCRIPTION
Port the Molecule Torque calculation, performed in CalculateEnergy::CalculateTorque to the GPU. This will reduce the number of arrays that need to be copied between the CPU and GPU when performing a force-based multi-particle move.